### PR TITLE
Experience will be visible on descending order based on the the starting year of that experience.

### DIFF
--- a/src/content/Homepage.tsx
+++ b/src/content/Homepage.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { Experience, Section } from '@/components/interface';
 import { Base, Column, Text } from '@/components/ui';
 import { ThemeConfig } from '@/utils';
+import { ExperienceProps } from '@/types';
 
 const Homepage = () => {
   const t = useTranslations('UI');
@@ -14,9 +15,14 @@ const Homepage = () => {
       return null;
     }
 
+    const sortExperienceFunction = (experience1: ExperienceProps, experience2: ExperienceProps): number => { 
+      return (experience2?.yearStart?.getTime() - experience1?.yearStart?.getTime() ||
+              experience1?.yearEnd?.getTime() - experience2?.yearEnd?.getTime()) 
+    }
+    const sortedExperience = ThemeConfig?.experience?.sort(sortExperienceFunction) || [];
     return (
       <Column gap={16}>
-        {ThemeConfig.experience.map((experience) => {
+        {sortedExperience.map((experience) => {
           return (
             <Experience
               key={experience.expId}


### PR DESCRIPTION
Resolved issue 'Sort Experience by Most Recent Date #1'

- It is verified via adding different dates of experience. 
- It will be sorted based on the starting year of the experience
- And if the starting year will be the same then it will be sorted based on the ending year in ascending order.